### PR TITLE
Add estimate wizard view and template

### DIFF
--- a/apps/estimates/tests/test_views.py
+++ b/apps/estimates/tests/test_views.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from apps.estimates.models import Inquiry
+
+
+@pytest.mark.django_db
+def test_get_renders_first_slide(client):
+    response = client.get("/estimate/")
+    assert response.status_code == 200
+    assert b'name="lot_size_acres"' in response.content
+
+
+@pytest.mark.django_db
+def test_post_creates_inquiry(client):
+    data = {
+        "address": "123 Main St",
+        "lot_size_acres": 2,
+        "current_property": "House",
+        "property_goal": "Expand",
+        "investment_commitment": "100000",
+        "excitement_notes": "Very excited",
+    }
+    response = client.post(
+        "/estimate/",
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert Inquiry.objects.count() == 1
+    inquiry = Inquiry.objects.get()
+    assert inquiry.address == "123 Main St"
+    assert float(inquiry.lot_size_acres) == 2.0
+    assert inquiry.user_context["current_property"] == "House"

--- a/apps/estimates/views.py
+++ b/apps/estimates/views.py
@@ -1,0 +1,31 @@
+import json
+from decimal import Decimal
+
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+
+from .models import Inquiry
+
+
+@csrf_exempt
+async def estimate_wizard(request):
+    """Render the multi-step estimate wizard or persist an inquiry."""
+    if request.method == "GET":
+        return render(request, "estimates/wizard.html")
+
+    if request.method == "POST":
+        body = await request.body
+        data = json.loads(body or b"{}")
+        address = data.get("address", "")
+        lot_size_acres = Decimal(str(data.get("lot_size_acres", 0)))
+
+        inquiry = await Inquiry.objects.acreate(
+            address=address,
+            lot_size_acres=lot_size_acres,
+            user_context=data,
+        )
+
+        return JsonResponse({"id": inquiry.id})
+
+    return JsonResponse({"detail": "Method not allowed"}, status=405)

--- a/project/settings.py
+++ b/project/settings.py
@@ -32,7 +32,7 @@ ROOT_URLCONF = "project.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/project/urls.py
+++ b/project/urls.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import path
 
+from apps.estimates.views import estimate_wizard
+
 
 def index(request):
     return HttpResponse("Hello, world!")
@@ -10,4 +12,5 @@ def index(request):
 urlpatterns = [
     path("", index),
     path("admin/", admin.site.urls),
+    path("estimate/", estimate_wizard),
 ]

--- a/templates/estimates/wizard.html
+++ b/templates/estimates/wizard.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Estimate Wizard</title>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const slides = Array.from(document.querySelectorAll('.slide'));
+            let current = 0;
+
+            function showSlide(index) {
+                slides.forEach((slide, i) => {
+                    slide.classList.toggle('hidden', i !== index);
+                });
+            }
+
+            function validate(slide) {
+                const inputs = slide.querySelectorAll('input, textarea');
+                for (const input of inputs) {
+                    if (!input.value.trim()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            function collectData() {
+                const data = {};
+                document.querySelectorAll('input, textarea').forEach(el => {
+                    data[el.name] = el.value;
+                });
+                return data;
+            }
+
+            function submitData() {
+                const payload = collectData();
+                fetch('', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+                    },
+                    body: JSON.stringify(payload)
+                }).then(resp => {
+                    if (resp.ok) {
+                        document.getElementById('thanks').classList.remove('hidden');
+                    }
+                });
+            }
+
+            document.querySelectorAll('[data-next]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const slide = slides[current];
+                    if (!validate(slide)) {
+                        alert('Please fill out all fields');
+                        return;
+                    }
+                    current += 1;
+                    if (current >= slides.length) {
+                        submitData();
+                    } else {
+                        showSlide(current);
+                    }
+                });
+            });
+
+            showSlide(current);
+        });
+    </script>
+</head>
+<body class="p-4">
+    <form>
+        {% csrf_token %}
+        <div class="slide">
+            <input type="number" name="lot_size_acres" class="border p-2 block mb-2" placeholder="Lot size (acres)" />
+            <input type="text" name="address" class="border p-2 block" placeholder="Address" />
+            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+        </div>
+        <div class="slide hidden">
+            <textarea name="current_property"
+                      class="border p-2 w-full"
+                      placeholder="Describe current property"></textarea>
+            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+        </div>
+        <div class="slide hidden">
+            <textarea name="property_goal"
+                      class="border p-2 w-full"
+                      placeholder="What's your property goal?"></textarea>
+            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+        </div>
+        <div class="slide hidden">
+            <textarea name="investment_commitment"
+                      class="border p-2 w-full"
+                      placeholder="Investment commitment"></textarea>
+            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+        </div>
+        <div class="slide hidden">
+            <textarea name="excitement_notes"
+                      class="border p-2 w-full"
+                      placeholder="What excites you about this project?"></textarea>
+            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Submit</button>
+        </div>
+    </form>
+    <div id="thanks" class="hidden">Thank you for your submission!</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add async estimate wizard view to gather prospect info
- tailwind-styled multi-slide wizard template with client-side JS
- wire up routing and template directory
- test view GET and POST behavior

## Testing
- `pytest` *(fails: No module named 'django')*
- `pip install django pytest pytest-django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a119364c8325b7499c0cfc5e50bb