### PR TITLE
Add Tailwind and green theme to estimate wizard

### DIFF
--- a/templates/estimates/wizard.html
+++ b/templates/estimates/wizard.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Estimate Wizard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const slides = Array.from(document.querySelectorAll('.slide'));
@@ -68,37 +69,37 @@
         });
     </script>
 </head>
-<body class="p-4">
+<body class="min-h-screen bg-green-50 flex items-center justify-center p-4">
     <form>
         {% csrf_token %}
         <div class="slide">
             <input type="number" name="lot_size_acres" class="border p-2 block mb-2" placeholder="Lot size (acres)" />
             <input type="text" name="address" class="border p-2 block" placeholder="Address" />
-            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+            <button type="button" data-next class="mt-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2">Next</button>
         </div>
         <div class="slide hidden">
             <textarea name="current_property"
                       class="border p-2 w-full"
                       placeholder="Describe current property"></textarea>
-            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+            <button type="button" data-next class="mt-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2">Next</button>
         </div>
         <div class="slide hidden">
             <textarea name="property_goal"
                       class="border p-2 w-full"
                       placeholder="What's your property goal?"></textarea>
-            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+            <button type="button" data-next class="mt-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2">Next</button>
         </div>
         <div class="slide hidden">
             <textarea name="investment_commitment"
                       class="border p-2 w-full"
                       placeholder="Investment commitment"></textarea>
-            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Next</button>
+            <button type="button" data-next class="mt-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2">Next</button>
         </div>
         <div class="slide hidden">
             <textarea name="excitement_notes"
                       class="border p-2 w-full"
                       placeholder="What excites you about this project?"></textarea>
-            <button type="button" data-next class="mt-4 bg-blue-500 text-white px-4 py-2">Submit</button>
+            <button type="button" data-next class="mt-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2">Submit</button>
         </div>
     </form>
     <div id="thanks" class="hidden">Thank you for your submission!</div>


### PR DESCRIPTION
## Summary
- include Tailwind CSS CDN in estimate wizard
- switch wizard buttons to green palette and apply green base layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install 'Django>=5.0,<6'` *(fails: Could not find a version that satisfies the requirement Django<6,>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f7af58d883259d42f7cfe073622a