### PR TITLE
Hide estimate form after submission

### DIFF
--- a/templates/estimates/wizard.html
+++ b/templates/estimates/wizard.html
@@ -43,6 +43,7 @@
                     body: JSON.stringify(payload),
                 }).then(resp => {
                     if (resp.ok) {
+                        document.querySelector('form').classList.add('hidden');
                         document.getElementById('thanks').classList.remove('hidden');
                     }
                 });
@@ -107,6 +108,9 @@
             </div>
         </div>
     </form>
-    <div id="thanks" class="hidden mt-4 text-center text-green-800">Thank you for your submission!</div>
+    <div id="thanks" class="hidden mt-4 text-center text-green-800">
+        <p>Thank you for your submission!</p>
+        <p><a href="" class="underline text-green-600">Make another estimate</a></p>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide wizard form after successful submission
- show thank you message with link to make another estimate

## Testing
- ⚠️ `pre-commit run --files templates/estimates/wizard.html` (pre-commit not installed)
- ❌ `pyright` (Cannot access attribute "id" for class "Inquiry")

------
https://chatgpt.com/codex/tasks/task_e_68b324cce2b48325afbcbf4236f67cd7