### PR TITLE
Hide estimate form after submission

### DIFF
--- a/apps/estimates/migrations/0002_update_inquiry_fields.py
+++ b/apps/estimates/migrations/0002_update_inquiry_fields.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("estimates", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="inquiry",
+            name="user_context",
+        ),
+        migrations.AddField(
+            model_name="inquiry",
+            name="current_property",
+            field=models.TextField(default=""),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="inquiry",
+            name="property_goal",
+            field=models.TextField(default=""),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="inquiry",
+            name="investment_commitment",
+            field=models.TextField(default=""),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="inquiry",
+            name="excitement_notes",
+            field=models.TextField(default=""),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="inquiry",
+            name="updated_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, auto_now=True),
+            preserve_default=False,
+        ),
+    ]

--- a/apps/estimates/models.py
+++ b/apps/estimates/models.py
@@ -4,8 +4,12 @@ from django.db import models
 class Inquiry(models.Model):
     address = models.CharField(max_length=255)
     lot_size_acres = models.DecimalField(max_digits=10, decimal_places=2)
-    user_context = models.JSONField()
+    current_property = models.TextField()
+    property_goal = models.TextField()
+    investment_commitment = models.TextField()
+    excitement_notes = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
 
 class Estimate(models.Model):

--- a/apps/estimates/tests/test_models.py
+++ b/apps/estimates/tests/test_models.py
@@ -8,7 +8,10 @@ def inquiry(db):
     return Inquiry.objects.create(
         address="123 Main St",
         lot_size_acres=1.5,
-        user_context={"owner": "Alice"},
+        current_property="House",
+        property_goal="Expand",
+        investment_commitment="100000",
+        excitement_notes="Excited",
     )
 
 

--- a/apps/estimates/tests/test_views.py
+++ b/apps/estimates/tests/test_views.py
@@ -32,4 +32,7 @@ def test_post_creates_inquiry(client):
     inquiry = Inquiry.objects.get()
     assert inquiry.address == "123 Main St"
     assert float(inquiry.lot_size_acres) == 2.0
-    assert inquiry.user_context["current_property"] == "House"
+    assert inquiry.current_property == "House"
+    assert inquiry.property_goal == "Expand"
+    assert inquiry.investment_commitment == "100000"
+    assert inquiry.excitement_notes == "Very excited"

--- a/apps/estimates/views.py
+++ b/apps/estimates/views.py
@@ -23,7 +23,10 @@ async def estimate_wizard(request):
         inquiry = await Inquiry.objects.acreate(
             address=address,
             lot_size_acres=lot_size_acres,
-            user_context=data,
+            current_property=data.get("current_property", ""),
+            property_goal=data.get("property_goal", ""),
+            investment_commitment=data.get("investment_commitment", ""),
+            excitement_notes=data.get("excitement_notes", ""),
         )
 
         return JsonResponse({"id": inquiry.id})

--- a/templates/estimates/wizard.html
+++ b/templates/estimates/wizard.html
@@ -43,6 +43,7 @@
                     body: JSON.stringify(payload),
                 }).then(resp => {
                     if (resp.ok) {
+                        document.querySelector('form').classList.add('hidden');
                         document.getElementById('thanks').classList.remove('hidden');
                     }
                 });
@@ -107,6 +108,9 @@
             </div>
         </div>
     </form>
-    <div id="thanks" class="hidden mt-4 text-center text-green-800">Thank you for your submission!</div>
+    <div id="thanks" class="hidden mt-4 text-center text-green-800">
+        <p>Thank you for your submission!</p>
+        <p><a href="" class="underline text-green-600">Make another estimate</a></p>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide wizard form after successful submission
- show thank you message with link to make another estimate
- persist inquiry form data in explicit model fields

## Testing
- ⚠️ `pre-commit run --files apps/estimates/models.py apps/estimates/views.py apps/estimates/tests/test_models.py apps/estimates/tests/test_views.py apps/estimates/migrations/0002_update_inquiry_fields.py` (pre-commit: command not found)
- ❌ `pyright` (Cannot access attribute "id" for class "Inquiry")
- ❌ `pytest` (ModuleNotFoundError: No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_68b324cce2b48325afbcbf4236f67cd7