### PR TITLE
Add project list and detail pages with navigation

### DIFF
--- a/apps/estimates/migrations/0003_estimate_projection_arrays.py
+++ b/apps/estimates/migrations/0003_estimate_projection_arrays.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("estimates", "0002_update_inquiry_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="estimate",
+            name="ten_year_revenue",
+            field=models.JSONField(default=list),
+        ),
+        migrations.AddField(
+            model_name="estimate",
+            name="ten_year_cost",
+            field=models.JSONField(default=list),
+        ),
+    ]

--- a/apps/estimates/models.py
+++ b/apps/estimates/models.py
@@ -22,4 +22,6 @@ class Estimate(models.Model):
     net_cash_flow = models.DecimalField(max_digits=12, decimal_places=2)
     revenue = models.DecimalField(max_digits=12, decimal_places=2)
     cost = models.DecimalField(max_digits=12, decimal_places=2)
+    ten_year_revenue = models.JSONField(default=list)
+    ten_year_cost = models.JSONField(default=list)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,16 +1,12 @@
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import path
 
-from apps.estimates.views import estimate_wizard
-
-
-def index(request):
-    return HttpResponse("Hello, world!")
+from apps.estimates.views import estimate_detail, estimate_wizard, home
 
 
 urlpatterns = [
-    path("", index),
+    path("", home, name="home"),
     path("admin/", admin.site.urls),
-    path("estimate/", estimate_wizard),
+    path("estimate/", estimate_wizard, name="estimate-wizard"),
+    path("estimate/<int:pk>/", estimate_detail, name="estimate-detail"),
 ]

--- a/templates/estimates/detail.html
+++ b/templates/estimates/detail.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>{{ estimate.project_name }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="min-h-screen bg-green-50">
+    <nav class="bg-green-600 p-4 text-white">
+        <a href="/" class="font-bold">Home</a>
+    </nav>
+    <div class="max-w-3xl mx-auto p-6 space-y-6">
+        <div class="text-center space-y-2">
+            <h1 class="text-2xl font-bold text-green-800" id="proj-name">{{ estimate.project_name }}</h1>
+            <p id="proj-description" class="text-gray-700">{{ estimate.description }}</p>
+        </div>
+
+        <div class="bg-white p-4 rounded-lg shadow">
+            <h2 class="text-lg font-semibold mb-2">Inquiry</h2>
+            <ul class="list-disc ml-4 space-y-1">
+                <li><strong>Address:</strong> {{ inquiry.address }}</li>
+                <li><strong>Lot size (acres):</strong> {{ inquiry.lot_size_acres }}</li>
+                <li><strong>Current property:</strong> {{ inquiry.current_property }}</li>
+                <li><strong>Property goal:</strong> {{ inquiry.property_goal }}</li>
+                <li><strong>Investment commitment:</strong> {{ inquiry.investment_commitment }}</li>
+                <li><strong>Excitement notes:</strong> {{ inquiry.excitement_notes }}</li>
+            </ul>
+        </div>
+
+        <div class="bg-white p-4 rounded-lg shadow">
+            <canvas id="cashflowChart" height="120"></canvas>
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm text-center border border-gray-200">
+                <thead class="bg-green-100">
+                    <tr>
+                        <th class="px-2 py-1 border">Year</th>
+                        <th class="px-2 py-1 border">Total Revenue</th>
+                        <th class="px-2 py-1 border">Total Costs</th>
+                        <th class="px-2 py-1 border">Net Cash Flow</th>
+                    </tr>
+                </thead>
+                <tbody id="cashflowTable"></tbody>
+            </table>
+        </div>
+
+        <p class="text-center"><a href="{% url 'estimate-wizard' %}" class="underline text-green-600">Make another estimate</a></p>
+    </div>
+
+    {{ estimate.ten_year_revenue|json_script:"revenues-data" }}
+    {{ estimate.ten_year_cost|json_script:"costs-data" }}
+    <script>
+        const revenues = JSON.parse(document.getElementById('revenues-data').textContent);
+        const costs = JSON.parse(document.getElementById('costs-data').textContent);
+        const netCashFlows = revenues.map((rev, i) => rev - costs[i]);
+        const years = Array.from({length: revenues.length}, (_, i) => i + 1);
+
+        const ctx = document.getElementById('cashflowChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: years,
+                datasets: [{
+                    label: 'Net Cash Flow',
+                    data: netCashFlows,
+                    backgroundColor: netCashFlows.map(v => v < 0 ? '#dc2626' : '#16a34a')
+                }]
+            },
+            options: {
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: { beginAtZero: true }
+                }
+            }
+        });
+
+        const tbody = document.getElementById('cashflowTable');
+        years.forEach((year, i) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td class="border px-2 py-1">${year}</td>
+                <td class="border px-2 py-1">${revenues[i].toLocaleString()}</td>
+                <td class="border px-2 py-1">${costs[i].toLocaleString()}</td>
+                <td class="border px-2 py-1 ${netCashFlows[i] < 0 ? 'text-red-600' : 'text-green-600'}">${netCashFlows[i].toLocaleString()}</td>
+            `;
+            tbody.appendChild(row);
+        });
+    </script>
+</body>
+</html>

--- a/templates/estimates/wizard.html
+++ b/templates/estimates/wizard.html
@@ -122,7 +122,11 @@
         });
     </script>
 </head>
-<body class="min-h-screen bg-green-50 flex items-center justify-center p-4">
+<body class="min-h-screen bg-green-50 p-4">
+    <nav class="bg-green-600 p-4 text-white mb-4">
+        <a href="/" class="font-bold">Home</a>
+    </nav>
+    <div class="flex items-center justify-center">
     <!-- Loading Overlay -->
     <div id="loading" class="hidden fixed inset-0 flex flex-col items-center justify-center bg-white bg-opacity-80 z-50">
         <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
@@ -189,7 +193,8 @@
             </table>
         </div>
 
-        <p class="text-center"><a href="" class="underline text-green-600">Make another estimate</a></p>
+        <p class="text-center"><a href="{% url 'estimate-wizard' %}" class="underline text-green-600">Make another estimate</a></p>
+    </div>
     </div>
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Projects</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-green-50">
+    <nav class="bg-green-600 p-4 text-white">
+        <a href="/" class="font-bold">Home</a>
+    </nav>
+    <div class="max-w-xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-4">Projects</h1>
+        <ul class="space-y-2 mb-6">
+            {% for estimate in estimates %}
+                <li>
+                    <a href="{% url 'estimate-detail' estimate.id %}" class="text-green-700 underline">{{ estimate.project_name }}</a>
+                </li>
+            {% empty %}
+                <li class="text-gray-600">No projects yet.</li>
+            {% endfor %}
+        </ul>
+        <a href="{% url 'estimate-wizard' %}" class="text-green-700 underline">+ Create new project</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create a home page listing saved project estimates with a link to create new ones
- Persist estimate projections and show them on a new detail page alongside inquiry data
- Add navigation bar across pages and wire up new routes

## Testing
- `pre-commit run --files apps/estimates/models.py apps/estimates/views.py templates/home.html templates/estimates/detail.html templates/estimates/wizard.html project/urls.py apps/estimates/migrations/0003_estimate_projection_arrays.py` *(fails: command not found: pre-commit)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b4023c6c208325bd9cf7bca1e217d0