### PR TITLE
test: add async tests for models, views, and AI service

### DIFF
--- a/apps/estimates/tests/test_ai_service.py
+++ b/apps/estimates/tests/test_ai_service.py
@@ -1,0 +1,41 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from apps.estimates.utils import FarmInput, FarmProjection, estimate_farm_projection
+
+
+@pytest.mark.anyio
+async def test_estimate_farm_projection(monkeypatch) -> None:
+    farm_input = FarmInput(
+        address="123 Main St",
+        lot_size_acres=1.0,
+        current_property="House",
+        property_goal="Expand",
+        investment_commitment="100000",
+        excitement_notes="Excited",
+    )
+
+    fake_projection = {
+        "name": "Test Project",
+        "description": "desc",
+        "ten_year_revenue": [1] * 10,
+        "ten_year_cost": [2] * 10,
+    }
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=json.dumps(fake_projection))
+            )
+        ]
+    )
+
+    monkeypatch.setattr(
+        "apps.estimates.utils.client.chat.completions.create",
+        lambda *args, **kwargs: fake_response,
+    )
+
+    projection = estimate_farm_projection(farm_input)
+    assert projection == FarmProjection(**fake_projection)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pyright>=1.1.404",
     "pytest>=8.4.1",
     "pytest-django>=4.11.1",
+    "pytest-anyio>=0.9.0",
     "ruff>=0.12.11",
 ]
 


### PR DESCRIPTION
## Summary
- add `pytest-anyio` dev dependency
- cover model, view, and AI service with async tests
- mock OpenAI calls in view and AI service tests to avoid network usage

## Testing
- `pre-commit run --files pyproject.toml apps/estimates/tests/test_models.py apps/estimates/tests/test_views.py apps/estimates/tests/test_ai_service.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pip install django pytest-django pytest-anyio` *(failed: Could not find a version that satisfies the requirement django)*
- `DJANGO_SETTINGS_MODULE=project.settings pytest` *(errors: ModuleNotFoundError: No module named 'openai'; ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68b4091c644c8325b3ea279683a796c4