### PR TITLE
chore: update dev dependencies for anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "anyio>=4.0.0",
     "django-stubs>=5.2.2",
     "ipdb>=0.13.13",
     "pre-commit>=4.3.0",
     "pyright>=1.1.404",
     "pytest>=8.4.1",
     "pytest-django>=4.11.1",
-    "pytest-anyio>=0.9.0",
     "ruff>=0.12.11",
 ]
 


### PR DESCRIPTION
## Summary
- replace pytest-anyio with anyio as dev dependency

## Testing
- `uv lock` *(fails: Failed to fetch `https://pypi.org/simple/pytest-django/`)*
- `uv sync` *(fails: Failed to fetch `https://pypi.org/simple/ipdb/`)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b40c03210c8325a20b1b3a96868c87