### PR TITLE
Add trio dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-django>=4.11.1",
     "ruff>=0.12.11",
+    "trio>=0.26",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add trio>=0.26 to dev dependency group

## Testing
- `uv lock` *(fails: Failed to fetch: `https://pypi.org/simple/pyright/`)*
- `uv sync` *(fails: Failed to fetch: `https://pypi.org/simple/ruff/`)*
- `pre-commit run --files pyproject.toml` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b4114861fc8325bb525375710cd81b