### PR TITLE
Fix async tests by selecting related inquiry and limiting backend

### DIFF
--- a/apps/estimates/models.py
+++ b/apps/estimates/models.py
@@ -13,6 +13,13 @@ class Inquiry(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
 
+class EstimateManager(models.Manager):
+    """Manager that fetches the related inquiry automatically."""
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("inquiry")
+
+
 class Estimate(models.Model):
     id: int
     inquiry = models.ForeignKey(
@@ -26,3 +33,5 @@ class Estimate(models.Model):
     ten_year_revenue = models.JSONField(default=list)
     ten_year_cost = models.JSONField(default=list)
     created_at = models.DateTimeField(auto_now_add=True)
+    objects = EstimateManager()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dev = [
     "pyright>=1.1.404",
     "pytest>=8.4.1",
     "pytest-django>=4.11.1",
-    "ruff>=0.12.11",
-    "trio>=0.26",
+    "ruff>=0.12.11"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- ensure Estimate queries automatically fetch the related Inquiry
- remove trio from dev dependencies to run tests under asyncio only

## Testing
- `pre-commit run --files apps/estimates/models.py pyproject.toml` *(fails: command not found)*
- `pytest` *(fails: No module named 'openai'; ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b413d86eb08325abd525716c9c46e5