### PR TITLE
Add asyncio backend fixture for anyio tests

### DIFF
--- a/apps/estimates/tests/conftest.py
+++ b/apps/estimates/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary
- add `anyio_backend` fixture returning `"asyncio"`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai', 'asgiref', 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b417c2005883258cc9d4198580a17a